### PR TITLE
Fix arrow image height on FF

### DIFF
--- a/components/QuoteScroller.vue
+++ b/components/QuoteScroller.vue
@@ -48,10 +48,10 @@
         padding: 0;
         transition: opacity .4s ease-in .2s;
         position: absolute;
-        top: 0;
+        top: 50%;
         bottom: 0;
+        margin-top: -1.25rem; // Half the height
         display: flex;
-        height: 100%;
 
         &:hover {
           cursor: pointer;


### PR DESCRIPTION
The bug on FF that this PR fixes:

<img width="942" alt="screen shot 2018-11-26 at 10 07 06 am" src="https://user-images.githubusercontent.com/171493/49022638-4ff03a00-f163-11e8-8e39-779a0f0a1bd6.png">
